### PR TITLE
画面サイズをブラウザのサイズから取得

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,8 +11,9 @@ import { config, jpnname2engname } from "./config.js";
 import { Sound, Volume } from "./components/sound.js";
 
 // 画面サイズ
-const SCREEN_W = document.documentElement.clientWidth;
+// const SCREEN_W = document.documentElement.clientWidth;
 const SCREEN_H = document.documentElement.clientHeight;
+const SCREEN_W = SCREEN_H * 16 / 9;
 
 const URI = config["URI"]
 let client_status = "offline"

--- a/app.js
+++ b/app.js
@@ -11,8 +11,8 @@ import { config, jpnname2engname } from "./config.js";
 import { Sound, Volume } from "./components/sound.js";
 
 // 画面サイズ
-const SCREEN_W = 1600 * 0.8;
-const SCREEN_H = 900 * 0.8;
+const SCREEN_W = document.documentElement.clientWidth;
+const SCREEN_H = document.documentElement.clientHeight;
 
 const URI = config["URI"]
 let client_status = "offline"


### PR DESCRIPTION
* 退出ボタンがスクロールしないと見えていなかったのが画面内に収まるようになった
* TODO: 画面を開いた後にブラウザのサイズを変えても変更されない。リロード時のみ
  * window.onresize で動くようにもすべきかも
* TODO:役職設定のモーダルのサイズが微妙